### PR TITLE
Template should not impose ``title`` formatting

### DIFF
--- a/djangocms_teaser/templates/cms/plugins/teaser.html
+++ b/djangocms_teaser/templates/cms/plugins/teaser.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<h2>{{ object.title|title }}</h2>
+<h2>{{ object.title }}</h2>
 {% if object.image %}
 	{% if link %}<a href="{{ link }}">{% endif %}
 		<img src="{{ object.image.url }}" alt="{{ object.title }}"/>


### PR DESCRIPTION
If the teaser title is entered as "IBM News", the default template should not forcefully reformat this as "Ibm News". If users are comfortable using the `title` filter as a site-wide policy, they can easily override the template. But in the default case, it should assume the content editors are consenting adults capable of correctly using upper and lower case letters.
